### PR TITLE
Added "# encoding: utf-8" header to prevent encoding errors with «» and

### DIFF
--- a/lib/mt940.rb
+++ b/lib/mt940.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'mt940/customer_statement_message'
 
 class MT940


### PR DESCRIPTION
Added "# encoding: utf-8" header to prevent encoding errors with «» and ruby 1.9x
