### PR TITLE
Make `content` accessible on parsed objects

### DIFF
--- a/lib/mt940.rb
+++ b/lib/mt940.rb
@@ -36,6 +36,7 @@ class MT940
 
     def initialize(modifier, content)
       @modifier = modifier
+      @content = content
       parse_content(content)
     end
 


### PR DESCRIPTION
This tweaks `MT940::Field` so that the unparsed data is stored as the `@content` instance variable and is available publicly via an `attr_reader`. At the moment, there's an `attr_reader` but the raw MT940 text isn't actually stored so it'll always be `nil`.

This is proving useful for my usage of the gem since our bank formats its field 86 (i.e. `MT940::StatementLineInformation`) in its own proprietary way that we want to be able to write a parser for, whilst still making use of the rest of the gem's functionality.

PS: Thanks for this excellent gem! Great to have code available and open-sourced for such a critical standard.