### PR TITLE
Make Field 25 compatible with specification

### DIFF
--- a/lib/mt940.rb
+++ b/lib/mt940.rb
@@ -18,7 +18,7 @@ class MT940
           klass = {
             '20' => Job,
             '21' => Reference,
-            '25' => Account,
+            '25' => AccountIdentification,
             '28' => Statement,
             '60' => AccountBalance,
             '61' => StatementLine,
@@ -80,6 +80,30 @@ class MT940
   end
 
   # 25
+  class AccountIdentification < Field
+    attr_reader :account_identifier
+    CONTENT = /(.{1,35})/ #any 35 chars (35x from the docs)
+
+    def parse_content(content)
+      content.match(CONTENT)
+      @account_identifier = $1
+    end
+
+    # fail over to the old Account class
+    def method_missing(method, *args, &block)
+      @fail_over_implementation ||= Account.new(@modifier, @content)
+      value = @fail_over_implementation.send(method)
+      warn "[DEPRECATION]:"
+      warn "You used '#{method}' on the Account/AccountIdentification class"
+      warn "This field is not part of the MT940 specification but implementation specific"
+      warn "Please use the 'account_identifier' and parse yourself."
+
+      value
+    end
+  end
+
+  # 25 - Legacy
+  # This class is deprecated as it does not match the spec.
   class Account < Field
     attr_reader :bank_code, :account_number, :account_currency
 

--- a/lib/mt940/customer_statement_message.rb
+++ b/lib/mt940/customer_statement_message.rb
@@ -16,7 +16,7 @@ class MT940
     end
 
     def initialize(lines)
-      @account = lines.find { |line| line.class == MT940::Account }
+      @account = lines.find { |line| line.class == MT940::AccountIdentification }
       @statement_lines = []
       lines.each_with_index do |line, i|
         next unless line.class == MT940::StatementLine

--- a/test/fixtures/currency_in_25.yml
+++ b/test/fixtures/currency_in_25.yml
@@ -1,7 +1,5 @@
 ---
-- - !ruby/object:MT940::Account
+- - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 51210600/9223382012EUR
-    bank_code: '51210600'
-    account_number: '9223382012'
-    account_currency: EUR
+    account_identifier: 51210600/9223382012EUR

--- a/test/fixtures/sepa_mt9401.yml
+++ b/test/fixtures/sepa_mt9401.yml
@@ -3,12 +3,10 @@
     modifier: 
     content: T089413946000001
     reference: T089413946000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194774600888
-    bank_code: '50880050'
-    account_number: 0194774600888
-    account_currency: 
+    account_identifier: 50880050/0194774600888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -192,12 +190,10 @@
     modifier: 
     content: T089413956000001
     reference: T089413956000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194777100888
-    bank_code: '50880050'
-    account_number: 0194777100888
-    account_currency: 
+    account_identifier: 50880050/0194777100888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -297,12 +293,10 @@
     modifier: 
     content: T089413966000001
     reference: T089413966000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194778300888
-    bank_code: '50880050'
-    account_number: 0194778300888
-    account_currency: 
+    account_identifier: 50880050/0194778300888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -477,12 +471,10 @@
     modifier: 
     content: T089413976000001
     reference: T089413976000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194779500888
-    bank_code: '50880050'
-    account_number: 0194779500888
-    account_currency: 
+    account_identifier: 50880050/0194779500888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -605,12 +597,10 @@
     modifier: 
     content: T089413986000001
     reference: T089413986000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194780100888
-    bank_code: '50880050'
-    account_number: 0194780100888
-    account_currency: 
+    account_identifier: 50880050/0194780100888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -751,12 +741,10 @@
     modifier: 
     content: T089413996000001
     reference: T089413996000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194780101888
-    bank_code: '50880050'
-    account_number: 0194780101888
-    account_currency: 
+    account_identifier: 50880050/0194780101888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -818,12 +806,10 @@
     modifier: 
     content: T089414006000001
     reference: T089414006000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194781300888
-    bank_code: '50880050'
-    account_number: 0194781300888
-    account_currency: 
+    account_identifier: 50880050/0194781300888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -985,12 +971,10 @@
     modifier: 
     content: T089414006000002
     reference: T089414006000002
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194781300888
-    bank_code: '50880050'
-    account_number: 0194781300888
-    account_currency: 
+    account_identifier: 50880050/0194781300888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00002
@@ -1158,12 +1142,10 @@
     modifier: 
     content: T089414016000001
     reference: T089414016000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194782500888
-    bank_code: '50880050'
-    account_number: 0194782500888
-    account_currency: 
+    account_identifier: 50880050/0194782500888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -1383,12 +1365,10 @@
     modifier: 
     content: T089414016000002
     reference: T089414016000002
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194782500888
-    bank_code: '50880050'
-    account_number: 0194782500888
-    account_currency: 
+    account_identifier: 50880050/0194782500888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00002
@@ -1490,12 +1470,10 @@
     modifier: 
     content: T089414026000001
     reference: T089414026000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194783700888
-    bank_code: '50880050'
-    account_number: 0194783700888
-    account_currency: 
+    account_identifier: 50880050/0194783700888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -1685,12 +1663,10 @@
     modifier: 
     content: T089414026000002
     reference: T089414026000002
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194783700888
-    bank_code: '50880050'
-    account_number: 0194783700888
-    account_currency: 
+    account_identifier: 50880050/0194783700888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00002
@@ -1878,12 +1854,10 @@
     modifier: 
     content: T089414036000001
     reference: T089414036000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194784900888
-    bank_code: '50880050'
-    account_number: 0194784900888
-    account_currency: 
+    account_identifier: 50880050/0194784900888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -2068,12 +2042,10 @@
     modifier: 
     content: T089414036000002
     reference: T089414036000002
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194784900888
-    bank_code: '50880050'
-    account_number: 0194784900888
-    account_currency: 
+    account_identifier: 50880050/0194784900888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00002
@@ -2173,12 +2145,10 @@
     modifier: 
     content: T089414046000001
     reference: T089414046000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194784901888
-    bank_code: '50880050'
-    account_number: 0194784901888
-    account_currency: 
+    account_identifier: 50880050/0194784901888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00003/00001
@@ -2245,12 +2215,10 @@
     modifier: 
     content: T089414056000001
     reference: T089414056000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194785000888
-    bank_code: '50880050'
-    account_number: 0194785000888
-    account_currency: 
+    account_identifier: 50880050/0194785000888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -2421,12 +2389,10 @@
     modifier: 
     content: T089414056000002
     reference: T089414056000002
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194785000888
-    bank_code: '50880050'
-    account_number: 0194785000888
-    account_currency: 
+    account_identifier: 50880050/0194785000888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00002
@@ -2594,12 +2560,10 @@
     modifier: 
     content: T089414056000003
     reference: T089414056000003
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194785000888
-    bank_code: '50880050'
-    account_number: 0194785000888
-    account_currency: 
+    account_identifier: 50880050/0194785000888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00003
@@ -2696,12 +2660,10 @@
     modifier: 
     content: T089414066000001
     reference: T089414066000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194785001888
-    bank_code: '50880050'
-    account_number: 0194785001888
-    account_currency: 
+    account_identifier: 50880050/0194785001888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -2763,12 +2725,10 @@
     modifier: 
     content: T089414076000001
     reference: T089414076000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194786200888
-    bank_code: '50880050'
-    account_number: 0194786200888
-    account_currency: 
+    account_identifier: 50880050/0194786200888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -2891,12 +2851,10 @@
     modifier: 
     content: T089414086000001
     reference: T089414086000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194787400888
-    bank_code: '50880050'
-    account_number: 0194787400888
-    account_currency: 
+    account_identifier: 50880050/0194787400888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -3043,12 +3001,10 @@
     modifier: 
     content: T089414096000001
     reference: T089414096000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194791600888
-    bank_code: '50880050'
-    account_number: 0194791600888
-    account_currency: 
+    account_identifier: 50880050/0194791600888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -3264,12 +3220,10 @@
     modifier: 
     content: T089414106000001
     reference: T089414106000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194791601888
-    bank_code: '50880050'
-    account_number: 0194791601888
-    account_currency: 
+    account_identifier: 50880050/0194791601888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -3385,12 +3339,10 @@
     modifier: 
     content: T089414116000001
     reference: T089414116000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194798900888
-    bank_code: '50880050'
-    account_number: 0194798900888
-    account_currency: 
+    account_identifier: 50880050/0194798900888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -3448,12 +3400,10 @@
     modifier: 
     content: T089414126000001
     reference: T089414126000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194799000888
-    bank_code: '50880050'
-    account_number: 0194799000888
-    account_currency: 
+    account_identifier: 50880050/0194799000888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00004/00001
@@ -3511,12 +3461,10 @@
     modifier: 
     content: T089414136000001
     reference: T089414136000001
-  - !ruby/object:MT940::Account
+  - !ruby/object:MT940::AccountIdentification
     modifier: 
     content: 50880050/0194804000888
-    bank_code: '50880050'
-    account_number: 0194804000888
-    account_currency: 
+    account_identifier: 50880050/0194804000888
   - !ruby/object:MT940::Statement
     modifier: C
     content: 00001/00001

--- a/test/test_account_identifier.rb
+++ b/test/test_account_identifier.rb
@@ -1,0 +1,32 @@
+require_relative 'test_helper'
+
+class TestAccountIdentification < Test::Unit::TestCase
+  def test_account_identifier
+    acc_ident = MT940::AccountIdentification.new('','12345690')
+    assert_equal '12345690', acc_ident.account_identifier
+  end
+
+  def test_account_identifier_gets_the_first_35_characters
+    content = '1' * 40
+    acc_ident = MT940::AccountIdentification.new('', content)
+    assert_equal 35, acc_ident.account_identifier.length
+  end
+
+  def test_DEPRECATED_bank_code
+    content = '123456789/987EUR'
+    acc_ident = MT940::AccountIdentification.new('', content)
+    assert_equal '123456789', acc_ident.bank_code
+  end
+
+  def test_DEPRECATED_account_number
+    content = '123456789/987EUR'
+    acc_ident = MT940::AccountIdentification.new('', content)
+    assert_equal '987', acc_ident.account_number
+  end
+
+  def test_DEPRECATED_account_currency
+    content = '123456789/987EUR'
+    acc_ident = MT940::AccountIdentification.new('', content)
+    assert_equal 'EUR', acc_ident.account_currency
+  end
+end


### PR DESCRIPTION
The implementation for field 25 was assuming a Bank dependent format,
not directly compatible with the MT940 specification. It does additional
parsing by splitting the field into `bank_code`, `account_number` and
`account_currency`.

This patch introduces a new, specification compatible Class for field
25. It only provides the `account_identifier` field.

Backward compatibility on the API level is provided by falling back to
the original class when requested. It prints a deprecation warning in
this case.

The change is *not* compatible when dumping the objects as class names
and directly available fields have changed.